### PR TITLE
Utiliser merge plutôt que rebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ git pull
 
 ## On récupère les commits de master dans la branche
 git checkout branche_a_mettre_a_jour
-git rebase master
+git merge master
 ```
 
 _En savoir plus ici : https://guides.github.com/introduction/flow/_


### PR DESCRIPTION
Parce que c'est une commande assez dangereuse et difficile à utiliser à mon avis, je crois que ça facilitera la vie de tout le monde de faire comme ça à la place