### PR TITLE
added .classpath to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ target
 src/.DS_Store
 .project
 
+# file causing warnings
+project/.classpath
+
 #Annoying file
 sh.exe.stackdump
 


### PR DESCRIPTION
this file was causing warnings on my computer because it always switch configuration to JRE7 which does not support JavaFX => all javaFX classes are full of warnings