### PR TITLE
Ignorons donc la vue pour la couverture

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 ignore:
-  - "project/src/test"
+  - "project/src/test"  
+  - "project/src/main/java/org/apache/project/vue"
 
 coverage:
   range: 20..60

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ ignore:
   - "project/src/main/java/org/apache/project/vue"
 
 coverage:
-  range: 20..60
+  range: 30..75
   status:
       project: no
       patch: no


### PR DESCRIPTION
Le package vue n'est plus du tout concerné pour le calcul de la couverture des tests