### PR TITLE
Fix recalcul duree

### DIFF
--- a/project/src/main/java/org/apache/project/modele/Tournee.java
+++ b/project/src/main/java/org/apache/project/modele/Tournee.java
@@ -272,7 +272,6 @@ public class Tournee extends Observable {
 
 			// Mettre les intersections ordonnees (une a une)
 			// On n ajoute pas a la liste des intersections pour l entrepot
-			if (i + 1 < nombreChemins) {
 				Livraison livraisonActuelle = livraisonsOrdonnees.get(i);
 
 				livraisonActuelle.setHeureArrivee(PlageHoraire.calculerHeureArrivee(heureDepart, dureeTourneeSecondes));
@@ -287,7 +286,6 @@ public class Tournee extends Observable {
 				}
 
 				dureeTourneeSecondes += livraisonActuelle.getDuree();
-			}
 		}
 	}
 

--- a/project/src/main/java/org/apache/project/modele/Tournee.java
+++ b/project/src/main/java/org/apache/project/modele/Tournee.java
@@ -271,21 +271,20 @@ public class Tournee extends Observable {
 			dureeTourneeSecondes += chemins.get(i).getDuree();
 
 			// Mettre les intersections ordonnees (une a une)
-			// On n ajoute pas a la liste des intersections pour l entrepot
-				Livraison livraisonActuelle = livraisonsOrdonnees.get(i);
+			Livraison livraisonActuelle = livraisonsOrdonnees.get(i);
 
-				livraisonActuelle.setHeureArrivee(PlageHoraire.calculerHeureArrivee(heureDepart, dureeTourneeSecondes));
+			livraisonActuelle.setHeureArrivee(PlageHoraire.calculerHeureArrivee(heureDepart, dureeTourneeSecondes));
 
-				if (livraisonActuelle.getPlageHoraire() != null) {
-					// Ajout dans le temps de livraison le temps d attente
-					long avance = livraisonActuelle.getPlageHoraire().getDebut().getTime()
-							- livraisonActuelle.getHeureArrivee().getTime();
-					if (avance > 0) {
-						dureeTourneeSecondes += (int) Math.ceil(avance / 1000);
-					}
+			if (livraisonActuelle.getPlageHoraire() != null) {
+				// Ajout dans le temps de livraison le temps d attente
+				long avance = livraisonActuelle.getPlageHoraire().getDebut().getTime()
+						- livraisonActuelle.getHeureArrivee().getTime();
+				if (avance > 0) {
+					dureeTourneeSecondes += (int) Math.ceil(avance / 1000);
 				}
+			}
 
-				dureeTourneeSecondes += livraisonActuelle.getDuree();
+			dureeTourneeSecondes += livraisonActuelle.getDuree();
 		}
 	}
 

--- a/project/src/main/java/org/apache/project/modele/Tournee.java
+++ b/project/src/main/java/org/apache/project/modele/Tournee.java
@@ -266,10 +266,6 @@ public class Tournee extends Observable {
 
 		for (int i = 0; i < nombreChemins; i++) {
 
-			// Mettre a jour les heures pour chaque chemin
-
-			dureeTourneeSecondes += chemins.get(i).getDuree();
-
 			// Mettre les intersections ordonnees (une a une)
 			Livraison livraisonActuelle = livraisonsOrdonnees.get(i);
 
@@ -285,6 +281,10 @@ public class Tournee extends Observable {
 			}
 
 			dureeTourneeSecondes += livraisonActuelle.getDuree();
+			
+			// Mettre a jour les heures pour chaque chemin
+
+			dureeTourneeSecondes += chemins.get(i).getDuree();
 		}
 	}
 

--- a/project/src/test/java/org/apache/modele/TestCUAjoutLivraison.java
+++ b/project/src/test/java/org/apache/modele/TestCUAjoutLivraison.java
@@ -81,16 +81,18 @@ public class TestCUAjoutLivraison {
 		assertEquals(anciensChemins.get(3), chemins.get(4));
 		assertEquals(anciensChemins.get(4), chemins.get(5));
 
-		/*
-		 * NE FONCTIONNE PAS Verification de la mise a jour des horaires int
-		 * ancienneDuree = tournee.getDureeTourneeSecondes();
-		 * tournee.miseAJourHeureDuree();
-		 * 
-		 * int nouvelleDuree = tournee.getDureeTourneeSecondes();
-		 * 
-		 * assertTrue(ancienneDuree != nouvelleDuree); //La duree a bien ete changee
-		 * assertEquals(3043, nouvelleDuree);
-		 */
+		
+		 
+		 int ancienneDuree = tournee.getDureeTourneeSecondes();
+		 System.out.println(ancienneDuree);
+		 
+		 tournee.calculerDureeTotale();
+		 
+		 int nouvelleDuree = tournee.getDureeTourneeSecondes();
+		 
+		 
+		 assertTrue(ancienneDuree < nouvelleDuree); //La duree a bien ete changee
+		 assertEquals(3873, nouvelleDuree);
 	}
 
 	@Test(timeout = 1000)

--- a/project/src/test/java/org/apache/modele/TestCUAjoutLivraison.java
+++ b/project/src/test/java/org/apache/modele/TestCUAjoutLivraison.java
@@ -80,19 +80,15 @@ public class TestCUAjoutLivraison {
 		assertEquals(anciensChemins.get(2), chemins.get(3));
 		assertEquals(anciensChemins.get(3), chemins.get(4));
 		assertEquals(anciensChemins.get(4), chemins.get(5));
-
 		
+		int ancienneDuree = tournee.getDureeTourneeSecondes();
 		 
-		 int ancienneDuree = tournee.getDureeTourneeSecondes();
-		 System.out.println(ancienneDuree);
+		tournee.calculerDureeTotale();
 		 
-		 tournee.calculerDureeTotale();
+		int nouvelleDuree = tournee.getDureeTourneeSecondes();
 		 
-		 int nouvelleDuree = tournee.getDureeTourneeSecondes();
-		 
-		 
-		 assertTrue(ancienneDuree < nouvelleDuree); //La duree a bien ete changee
-		 assertEquals(3873, nouvelleDuree);
+		assertTrue(ancienneDuree < nouvelleDuree); //La duree a bien ete changee
+		assertEquals(3873, nouvelleDuree);
 	}
 
 	@Test(timeout = 1000)


### PR DESCRIPTION
Cette PR est liée à #171 

J'ai enlevé la condition `if (i + 1 < nombreChemins)` dans la méthode `Tournee.calculerDureeTotale()`, et il semble que la durée totale de tournée augmente au lieu de diminuer comme elle le faisait. Le test vérifie aussi ça maintenant.