### PR TITLE
Ignore Javadoc generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ target
 src/.DS_Store
 .project
 
+# Ignore Javadoc generated files
+project/doc
+
 # file causing warnings
 project/.classpath
 


### PR DESCRIPTION
Les fichiers générés par la Javadoc seront ignorés pour éviter des modifs en tous genre