### PR TITLE
correction bug annuler avec horaire invalide

### DIFF
--- a/project/src/main/java/org/apache/project/vue/EcouteurDeBouton.java
+++ b/project/src/main/java/org/apache/project/vue/EcouteurDeBouton.java
@@ -62,10 +62,8 @@ public class EcouteurDeBouton implements EventHandler<ActionEvent> {
 			case LivraisonPopup.CANCEL_ID:
 				LivraisonPopup popup2 = fenetrePrincipale.getFenetreAjouterLivraison();
 				if(popup2 != null) {
-					if(popup2.checkTimeOk()) {
-						controleur.annuler();	
-						fenetrePrincipale.masquerFenetreAjouterLivraison();
-					}
+					controleur.annuler();	
+					fenetrePrincipale.masquerFenetreAjouterLivraison();
 				}
 				break;
 			case ModificationPopup.VALIDATE_ID:


### PR DESCRIPTION
Bug: si on annule l'ajout alors que l'horaire est invalide, on ne peut pas annuler parce que l'horaire est invalide et l'interface nous ordonne d'entrer un horaire valide pour annuler.

excellent troll involontaire cela dit